### PR TITLE
Fix building with the latest libctru

### DIFF
--- a/Includes/stdafx.hpp
+++ b/Includes/stdafx.hpp
@@ -24,7 +24,7 @@
 #include "csvc.h"
 #include "libpon.hpp"
 #include "types.h"
-#include "unicode.h"
+#include "Unicode.h"
 
 namespace CTRPluginFramework {
 using CallbackPointer = void (*)();

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ARCH		:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 CFLAGS		:=	$(ARCH) -Os -mword-relocations \
 				-fomit-frame-pointer -ffunction-sections -fno-strict-aliasing
 
-CFLAGS		+=	$(INCLUDE) -DARM11 -D_3DS 
+CFLAGS		+=	$(INCLUDE) -D__3DS__
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 


### PR DESCRIPTION
This PR has two changes.

- Fixed filename (`unicode.h` -> `Unicode.h`)
- Replaced `-DARM11 -D_3DS` with `-D__3DS__` for the latest libctru